### PR TITLE
caligari: Enable fail2ban

### DIFF
--- a/machines/caligari.nix
+++ b/machines/caligari.nix
@@ -1,4 +1,6 @@
 { config, pkgs, lib, ... }:
 {
-  config = { };
+  config = { 
+    services.fail2ban.enable = true;
+  };
 }


### PR DESCRIPTION
The default configuration already supports sshd, which seems to be the biggest source of noise right now.