### PR TITLE
ananas/music-control: Cleanup DrawTarget::Error

### DIFF
--- a/apps/ananas-music-control/Cargo.lock
+++ b/apps/ananas-music-control/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rodio",
  "rppal",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-opentelemetry",

--- a/apps/ananas-music-control/Cargo.toml
+++ b/apps/ananas-music-control/Cargo.toml
@@ -16,6 +16,7 @@ opentelemetry-otlp = "0.14.0"
 opentelemetry_sdk = { version = "0.21.1", features = ["tokio"] }
 rodio = "0.17.3"
 rppal = "0.15.0"
+thiserror = "1.0.56"
 tokio = { version = "1.34.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.22.0"

--- a/apps/ananas-music-control/src/epaper.rs
+++ b/apps/ananas-music-control/src/epaper.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::Infallible,
     thread::sleep,
     time::{Duration, SystemTime},
 };
@@ -14,6 +13,8 @@ use rppal::{
     gpio::{InputPin, Level, OutputPin},
     spi::Spi,
 };
+
+use crate::gui::GuiError;
 
 const EPAPER_WIDTH: u32 = 122;
 const EPAPER_HEIGHT: u32 = 250;
@@ -318,7 +319,7 @@ impl DrawTarget for BufferedDrawTarget {
     type Color = BinaryColor;
 
     // fixme: make this a real error type, instead of panicking
-    type Error = Infallible;
+    type Error = GuiError;
 
     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
@@ -369,10 +370,9 @@ impl<T: DrawTarget + OriginDimensions + FlushableDrawTarget> RotatedDrawTarget<T
     }
 }
 
-impl<T: DrawTarget + OriginDimensions + FlushableDrawTarget> DrawTarget for RotatedDrawTarget<T> {
+impl<T: DrawTarget<Error = GuiError> + OriginDimensions + FlushableDrawTarget> DrawTarget for RotatedDrawTarget<T> {
     type Color = T::Color;
-
-    type Error = T::Error;
+    type Error = GuiError;
 
     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
     where

--- a/apps/ananas-music-control/src/gui/controls/button.rs
+++ b/apps/ananas-music-control/src/gui/controls/button.rs
@@ -4,30 +4,28 @@ use embedded_graphics::{
     pixelcolor::BinaryColor,
     primitives::{PrimitiveStyle, PrimitiveStyleBuilder, Rectangle, StyledDrawable},
 };
-use std::fmt::Debug;
-use std::{error::Error, sync::mpsc::Sender};
+use std::sync::mpsc::Sender;
 
-use crate::gui::{fonts::Fonts, Control, Dimensions, Event, GuiCommand, Padding, Point};
+use crate::gui::{fonts::Fonts, Control, Dimensions, Event, GuiCommand, Padding, Point, GuiError};
 
-type Callback<TDrawTarget, TError> = Box<dyn FnMut(Sender<GuiCommand<TDrawTarget, TError>>)>;
+type Callback<TDrawTarget> = Box<dyn FnMut(Sender<GuiCommand<TDrawTarget>>)>;
 
 pub struct Button<
-    TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>,
-    TError: Error + Debug,
+    TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>,
 > {
-    content: Box<dyn Control<TDrawTarget, TError>>,
-    action: Callback<TDrawTarget, TError>,
-    command_channel: Option<Sender<GuiCommand<TDrawTarget, TError>>>,
+    content: Box<dyn Control<TDrawTarget>>,
+    action: Callback<TDrawTarget>,
+    command_channel: Option<Sender<GuiCommand<TDrawTarget>>>,
     padding: Padding,
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    Button<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    Button<TDrawTarget>
 {
     pub fn new(
-        content: Box<dyn Control<TDrawTarget, TError>>,
+        content: Box<dyn Control<TDrawTarget>>,
         padding: Padding,
-        action: Callback<TDrawTarget, TError>,
+        action: Callback<TDrawTarget>,
     ) -> Self {
         Self {
             content,
@@ -45,8 +43,8 @@ const BUTTON_STYLE: PrimitiveStyle<BinaryColor> = PrimitiveStyleBuilder::new()
     .fill_color(BinaryColor::Off)
     .build();
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    Control<TDrawTarget, TError> for Button<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    Control<TDrawTarget> for Button<TDrawTarget>
 {
     fn render(
         &mut self,
@@ -102,7 +100,7 @@ impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error
 
     fn register_command_channel(
         &mut self,
-        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget, TError>>,
+        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget>>,
     ) {
         self.command_channel = Some(tx.clone());
         self.content.register_command_channel(tx);

--- a/apps/ananas-music-control/src/gui/controls/progress_bar.rs
+++ b/apps/ananas-music-control/src/gui/controls/progress_bar.rs
@@ -1,8 +1,6 @@
-use std::{
-    error::Error,
-    fmt::Debug,
-    sync::{mpsc::Sender, Arc},
-};
+use std::
+    sync::{mpsc::Sender, Arc}
+;
 
 use embedded_graphics::{
     draw_target::DrawTarget,
@@ -15,14 +13,13 @@ use crate::gui::{
     fonts::Fonts,
     geometry::Dimensions,
     reactivity::property::{ReactiveProperty, ReactivePropertyReceiver},
-    Control, Event, GuiCommand, Padding,
+    Control, Event, GuiCommand, Padding, GuiError,
 };
 
 pub struct ProgressBar<
-    TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>,
-    TError: Error + Debug,
+    TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>,
 > {
-    command_channel: Option<Sender<GuiCommand<TDrawTarget, TError>>>,
+    command_channel: Option<Sender<GuiCommand<TDrawTarget>>>,
     padding: Padding,
     progress: u32,
     progress_max: u32,
@@ -38,8 +35,8 @@ pub struct ProgressBar<
     progress_max_property_receiver: ReactivePropertyReceiver<u32>,
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    ProgressBar<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    ProgressBar<TDrawTarget>
 {
     pub fn new(progress: u32, progress_max: u32, height: u32, padding: Padding) -> Self {
         let (progress_property, progress_property_receiver) = ReactiveProperty::new();
@@ -68,10 +65,10 @@ impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error
     }
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    Control<TDrawTarget, TError> for ProgressBar<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    Control<TDrawTarget> for ProgressBar<TDrawTarget>
 {
-    fn register_command_channel(&mut self, tx: Sender<GuiCommand<TDrawTarget, TError>>) {
+    fn register_command_channel(&mut self, tx: Sender<GuiCommand<TDrawTarget>>) {
         self.command_channel = Some(tx);
     }
 

--- a/apps/ananas-music-control/src/gui/controls/stack_panel.rs
+++ b/apps/ananas-music-control/src/gui/controls/stack_panel.rs
@@ -1,32 +1,30 @@
 use std::cmp::max;
-use std::fmt::Debug;
 use std::sync::mpsc::Sender;
-use std::{collections::HashMap, error::Error};
+use std::collections::HashMap;
 
 use embedded_graphics::{draw_target::DrawTarget, pixelcolor::BinaryColor};
 
 use crate::gui::fonts::Fonts;
 use crate::gui::geometry::Rectangle;
 use crate::gui::layouts::stack::render_stack;
-use crate::gui::{Control, GuiCommand, Orientation, StackUnitDimension};
+use crate::gui::{Control, GuiCommand, Orientation, StackUnitDimension, GuiError};
 use crate::gui::{Dimensions, Point};
 
 pub struct StackPanel<
-    TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>,
-    TError: Error + Debug,
+    TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>,
 > {
-    children: Vec<Box<dyn Control<TDrawTarget, TError>>>,
+    children: Vec<Box<dyn Control<TDrawTarget>>>,
     bounding_boxes: HashMap<usize, Rectangle>,
     direction: Orientation,
-    command_channel: Option<Sender<GuiCommand<TDrawTarget, TError>>>,
+    command_channel: Option<Sender<GuiCommand<TDrawTarget>>>,
     unit_dimensions: Vec<StackUnitDimension>,
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    StackPanel<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    StackPanel<TDrawTarget>
 {
     pub fn new(
-        children: Vec<Box<dyn Control<TDrawTarget, TError>>>,
+        children: Vec<Box<dyn Control<TDrawTarget>>>,
         direction: Orientation,
         unit_dimensions: Vec<StackUnitDimension>,
     ) -> Self {
@@ -41,9 +39,8 @@ impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error
 }
 
 impl<
-        TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError> + 'static,
-        TError: Error + Debug + 'static,
-    > Control<TDrawTarget, TError> for StackPanel<TDrawTarget, TError>
+        TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError> + 'static,
+    > Control<TDrawTarget> for StackPanel<TDrawTarget>
 {
     fn render(
         &mut self,
@@ -99,7 +96,7 @@ impl<
 
     fn register_command_channel(
         &mut self,
-        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget, TError>>,
+        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget>>,
     ) {
         self.command_channel = Some(tx.clone());
 

--- a/apps/ananas-music-control/src/gui/controls/text.rs
+++ b/apps/ananas-music-control/src/gui/controls/text.rs
@@ -1,7 +1,6 @@
-use std::fmt::Debug;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
-use std::{cmp::min, error::Error};
+use std::cmp::min;
 
 use embedded_graphics::image::{Image, ImageRaw};
 use embedded_graphics::Drawable;
@@ -10,13 +9,13 @@ use fontdue::layout::{Layout, TextStyle};
 
 use crate::gui::fonts::{FontKind, Fonts};
 use crate::gui::reactivity::property::{ReactiveProperty, ReactivePropertyReceiver};
-use crate::gui::{Control, Dimensions, GuiCommand, Padding, Point};
+use crate::gui::{Control, Dimensions, GuiCommand, Padding, Point, GuiError};
 
-pub struct Text<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
+pub struct Text<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
 {
     text: String,
     font_size: usize,
-    command_channel: Option<Sender<GuiCommand<TDrawTarget, TError>>>,
+    command_channel: Option<Sender<GuiCommand<TDrawTarget>>>,
     padding: Padding,
     font_kind: FontKind,
 
@@ -27,8 +26,8 @@ pub struct Text<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TE
     dimensions: Option<Dimensions>,
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    Text<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    Text<TDrawTarget>
 {
     pub fn new(text: String, font_size: usize, font_kind: FontKind, padding: Padding) -> Self {
         let (text_property, text_property_receiver) = ReactiveProperty::new();
@@ -89,8 +88,8 @@ fn render_text(text: &str, font_size: f32, font_kind: FontKind, fonts: &Fonts) -
     }
 }
 
-impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error + Debug>
-    Control<TDrawTarget, TError> for Text<TDrawTarget, TError>
+impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError>>
+    Control<TDrawTarget> for Text<TDrawTarget>
 {
     fn render(
         &mut self,
@@ -169,7 +168,7 @@ impl<TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError>, TError: Error
 
     fn register_command_channel(
         &mut self,
-        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget, TError>>,
+        tx: std::sync::mpsc::Sender<crate::gui::GuiCommand<TDrawTarget>>,
     ) {
         self.command_channel = Some(tx);
     }

--- a/apps/ananas-music-control/src/gui/layouts/stack.rs
+++ b/apps/ananas-music-control/src/gui/layouts/stack.rs
@@ -1,18 +1,17 @@
-use std::{cmp::max, collections::BTreeMap, error::Error};
+use std::{cmp::max, collections::BTreeMap};
 
 use embedded_graphics::{draw_target::DrawTarget, pixelcolor::BinaryColor};
 
 use crate::gui::{
-    fonts::Fonts, geometry::Rectangle, Control, Dimensions, Orientation, Point, StackUnitDimension,
+    fonts::Fonts, geometry::Rectangle, Control, Dimensions, Orientation, Point, StackUnitDimension, GuiError,
 };
 
 pub fn render_stack<
     'a,
-    TDrawTarget: DrawTarget<Color = BinaryColor, Error = TError> + 'static,
-    TError: Error + 'static,
+    TDrawTarget: DrawTarget<Color = BinaryColor, Error = GuiError> + 'static,
 >(
     target: &mut TDrawTarget,
-    items: impl Iterator<Item = &'a mut Box<dyn Control<TDrawTarget, TError>>>,
+    items: impl Iterator<Item = &'a mut Box<dyn Control<TDrawTarget>>>,
     dimensions: Dimensions,
     position: Point,
     direction: Orientation,


### PR DESCRIPTION
We now require this type to be GuiError, which simplifies some type constraints