### PR TITLE
caligari: Register as multiple runners

### DIFF
--- a/machines/caligari/github-runner.nix
+++ b/machines/caligari/github-runner.nix
@@ -4,10 +4,15 @@
     file = ../../secrets/caligari-github-pat-runner-registration.age;
   };
 
-  services.github-runner = {
-    enable = true;
-    url = "https://github.com/ramonacat/nix-configs";
-    tokenFile = config.age.secrets.caligari-github-pat-runner-registration.path;
-    extraLabels = [ "nixos" ];
-  };
+  services.github-runners = builtins.listToAttrs (builtins.map
+    (i: {
+      name = "caligari-${toString i}";
+      value = {
+        enable = true;
+        url = "https://github.com/ramonacat/nix-configs";
+        tokenFile = config.age.secrets.caligari-github-pat-runner-registration.path;
+        extraLabels = [ "nixos" ];
+      };
+    })
+    (lib.range 0 6));
 }


### PR DESCRIPTION
One github runner can only run a single workflow. Many of the workflows are stuck on a single thread, underutilizng the computing resources. This PR registers 10 runners on the same machine, in order to allow running parallel workflows.