### PR TITLE
evillian: Fix sddm session

### DIFF
--- a/machines/evillian.nix
+++ b/machines/evillian.nix
@@ -1,9 +1,25 @@
 { config, pkgs, lib, ... }:
 {
   config = {
-    services.xserver.enable = true;
-    services.xserver.displayManager.sddm = {
+    services.xserver = {
       enable = true;
+      xkb.layout = "pl,de";
+    };
+    services.xserver.displayManager = {
+      lightdm = {
+        enable = true;
+        greeters = {
+          gtk = {
+            enable = true;
+          };
+        };
+      };
+      defaultSession = "sway";
+    };
+
+    programs.sway = {
+      enable = true;
+      wrapperFeatures.gtk = true;
     };
   };
 }


### PR DESCRIPTION
This commit fixes the sddm session (it was appearing empty). Also adds some scaling and enables non-us keyboard layouts.