### PR TITLE
angelsin: remove lan-mouse connection to the windows vm

### DIFF
--- a/users/ramona/gui.nix
+++ b/users/ramona/gui.nix
@@ -143,9 +143,6 @@
           hostname = "10.69.10.33"
           activate_on_startup = true
         '' else ''
-          [left]
-          hostname = "10.69.10.31"
-          activate_on_startup = true
           [bottom]
           hostname = "10.69.10.29"
           activate_on_startup = true


### PR DESCRIPTION
No longer needed, as it's now used thrugh looking-glass, which sends mouse over SPICE.