### PR TITLE
ci: Keep symlinks to built closures

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -22,6 +22,11 @@ build_closure "shadowmend"
 echo "On branch: $BRANCH_NAME"
 if [[ "$BRANCH_NAME" == "main" ]]; then
     scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 -- *-closure root@caligari:/var/www/ramona.fun/builds/
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 root@caligari -- "mkdir -p /var/closures/"
+    for filename in *-closure; do
+        CLOSURE=$(tr -d "\n" < "$filename")
+        ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_ed25519 root@caligari -- "ln -s $CLOSURE /var/closures/$filename"
+    done
 fi
 
 cat ./*-closure


### PR DESCRIPTION
This should prevent GC from removing them, which will should save us some rebuilds, and won't block machine updates if they happen to be ran after GC.