### PR TITLE
nixd: remove

### DIFF
--- a/users/ramona.nix
+++ b/users/ramona.nix
@@ -27,7 +27,6 @@
         jq
         atop
         ripgrep
-        nixd
         ratPackage
       ];
 


### PR DESCRIPTION
It was keeping an ancient version of nix installed, which didn't want to build anymore. Let's find another language server that is less outdated.