### PR TITLE
postgres: Do not compress backups

### DIFF
--- a/machines/hallewell/postgresql.nix
+++ b/machines/hallewell/postgresql.nix
@@ -59,7 +59,7 @@ in {
       backupPrepareCommand = ''
         mkdir ${backupPath}
         chown postgres:postgres ${backupPath}
-        ${pkgs.sudo}/bin/sudo -u postgres ${postgresPackage}/bin/pg_basebackup -Ft -Zzstd -Xstream -D${backupPath}
+        ${pkgs.sudo}/bin/sudo -u postgres ${postgresPackage}/bin/pg_basebackup -Xstream -D${backupPath}
       '';
       backupCleanupCommand = ''
         rm -r ${backupPath} || true


### PR DESCRIPTION
This way restic can do it's magic and hopefully use less space in the bucket