### PR TITLE
moonfall+caligari: Disable binary emulation

### DIFF
--- a/machines/caligari/hardware.nix
+++ b/machines/caligari/hardware.nix
@@ -5,7 +5,6 @@
       initrd.kernelModules = [];
       kernelModules = ["kvm-amd"];
       extraModulePackages = [];
-      binfmt.emulatedSystems = ["aarch64-linux"];
 
       loader.grub = {
         enable = true;

--- a/machines/moonfall/hardware.nix
+++ b/machines/moonfall/hardware.nix
@@ -5,7 +5,6 @@
       initrd.kernelModules = ["vfio_pci "];
       kernelModules = ["kvm-amd" "vfio" "vfio_pci" "vfio_iommu_type1" "vfio_virqfd" "amdgpu" "i2c-dev"];
       extraModulePackages = [];
-      binfmt.emulatedSystems = ["aarch64-linux"];
       loader.systemd-boot.enable = true;
       loader.efi.canTouchEfiVariables = true;
     };


### PR DESCRIPTION
Now we have a dedicated ARM builder, no need to duck around with qemu.